### PR TITLE
Feature: set external-controller from querystring

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,20 @@
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>
 <div id="root"></div>
+<script>
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    const { host, port, secret, protocol } = Object.fromEntries(
+        urlSearchParams.entries()
+    );
+    if (host && port) {
+        const meta = document.createElement("meta");
+        meta.name = "external-controller";
+        meta.content = `${protocol || window.location.protocol}//${
+            secret || ""
+        }@${host}:${port}`;
+        document.getElementsByTagName("head")[0].appendChild(meta);
+    }
+</script>
 <script type="module" src="/src/index.ts"></script>
 </body>
 </html>


### PR DESCRIPTION
Getting `location.search` in `useAPIInfo` doesn't work somehow.
Setting `external-controller` meta in vanilla javascript should be ok.