### PR TITLE
feat: add sniff host column to connections table

### DIFF
--- a/src/containers/Connections/Info/index.tsx
+++ b/src/containers/Connections/Info/index.tsx
@@ -40,6 +40,14 @@ export function ConnectionInfo (props: ConnectionsInfoProps) {
                 }</span>
             </div>
             <div className="flex my-3">
+                <span className="font-bold w-20">{t('info.host')}</span>
+                <span className="font-mono flex-1 break-all">{
+                    props.connection.metadata
+                        ? `${props.connection.metadata.sniffHost}`
+                        : t('info.hostEmpty')
+                }</span>
+            </div>
+            <div className="flex my-3">
                 <span className="font-bold w-20">{t('info.dstIP')}</span>
                 <span className="font-mono">{
                     props.connection.metadata

--- a/src/containers/Connections/index.tsx
+++ b/src/containers/Connections/index.tsx
@@ -20,6 +20,7 @@ import './style.scss'
 
 const Columns = {
     Host: 'host',
+    SniffHost: 'sniffHost',
     Network: 'network',
     Process: 'process',
     Type: 'type',
@@ -76,6 +77,7 @@ export default function Connections () {
         c => ({
             id: c.id,
             host: `${c.metadata.host || c.metadata.destinationIP}:${c.metadata.destinationPort}`,
+            sniffHost: c.metadata.sniffHost,
             chains: c.chains.slice().reverse().join(' / '),
             rule: c.rulePayload ? `${c.rule} :: ${c.rulePayload}` : c.rule,
             time: new Date(c.start).getTime(),
@@ -104,6 +106,7 @@ export default function Connections () {
     const columns = useMemo(
         () => table.createColumns([
             table.createDataColumn(Columns.Host, { minSize: 260, size: 260, header: t(`columns.${Columns.Host}`) }),
+            table.createDataColumn(Columns.SniffHost, { minSize: 260, size: 200, header: t(`columns.${Columns.SniffHost}`) }),
             table.createDataColumn(Columns.Network, { minSize: 80, size: 80, header: t(`columns.${Columns.Network}`) }),
             table.createDataColumn(Columns.Type, { minSize: 100, size: 100, header: t(`columns.${Columns.Type}`) }),
             table.createDataColumn(Columns.Chains, { minSize: 200, size: 200, header: t(`columns.${Columns.Chains}`) }),

--- a/src/containers/Connections/store.ts
+++ b/src/containers/Connections/store.ts
@@ -8,6 +8,7 @@ export type Connection = API.Connections & { completed?: boolean, uploadSpeed: n
 export interface FormatConnection {
     id: string
     host: string
+    sniffHost: string
     chains: string
     rule: string
     time: number

--- a/src/i18n/en_US.ts
+++ b/src/i18n/en_US.ts
@@ -68,6 +68,7 @@ const EN = {
         },
         columns: {
             host: 'Host',
+            sniffHost: 'Sniff Host',
             network: 'Network',
             type: 'Type',
             chains: 'Chains',

--- a/src/i18n/zh_CN.ts
+++ b/src/i18n/zh_CN.ts
@@ -68,6 +68,7 @@ const CN = {
         },
         columns: {
             host: '域名',
+            sniffHost: '嗅探域名',
             network: '网络',
             process: '进程',
             type: '类型',

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -90,6 +90,7 @@ export interface Connections {
         network: string
         type: string
         host: string
+        sniffHost: string
         processPath?: string
         sourceIP: string
         sourcePort: string


### PR DESCRIPTION
As the title suggests, this PR adds support for showing sniff host in connections table

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/17328586/219874762-2135df5c-773c-46e9-982a-0c1551ccc122.png">
